### PR TITLE
LogWatcher Module change required watcher.Close() to be changed to watcher.ConsumerGone()

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,4 +1,4 @@
-FROM  golang:1.7
+FROM  golang:1.11.5
 
-COPY . /go/src/github.com/cpuguy83/docker-log-driver
-RUN cd /go/src/github.com/cpuguy83/docker-log-driver && go get && go build --ldflags '-extldflags "-static"' -o /usr/bin/docker-log-driver
+COPY . /go/src/github.com/gforghetti/docker-log-driver
+RUN cd /go/src/github.com/gforghetti/docker-log-driver && go get && go build --ldflags '-extldflags "-static"' -o /usr/bin/docker-log-driver

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,4 +1,4 @@
 FROM  golang:1.11.5
 
-COPY . /go/src/github.com/gforghetti/docker-log-driver
-RUN cd /go/src/github.com/gforghetti/docker-log-driver && go get && go build --ldflags '-extldflags "-static"' -o /usr/bin/docker-log-driver
+COPY . /go/src/github.com/cpuguy83/docker-log-driver
+RUN cd /go/src/github.com/cpuguy83/docker-log-driver && go get && go build --ldflags '-extldflags "-static"' -o /usr/bin/docker-log-driver

--- a/driver.go
+++ b/driver.go
@@ -103,7 +103,11 @@ func consumeLog(lf *logPair) {
 		var msg logger.Message
 		msg.Line = buf.Line
 		msg.Source = buf.Source
-		//		msg.Partial = buf.Partial
+		if buf.PartialLogMetadata != nil {
+			msg.PLogMetaData.ID = buf.PartialLogMetadata.Id
+			msg.PLogMetaData.Last = buf.PartialLogMetadata.Last
+			msg.PLogMetaData.Ordinal = int(buf.PartialLogMetadata.Ordinal)
+		}
 		msg.Timestamp = time.Unix(0, buf.TimeNano)
 
 		if err := lf.l.Log(&msg); err != nil {
@@ -146,7 +150,7 @@ func (d *driver) ReadLogs(info logger.Info, config logger.ReadConfig) (io.ReadCl
 				}
 
 				buf.Line = msg.Line
-				//				buf.Partial = msg.Partial
+				buf.Partial = msg.PLogMetaData != nil
 				buf.TimeNano = msg.Timestamp.UnixNano()
 				buf.Source = msg.Source
 

--- a/driver.go
+++ b/driver.go
@@ -134,7 +134,7 @@ func (d *driver) ReadLogs(info logger.Info, config logger.ReadConfig) (io.ReadCl
 
 		enc := protoio.NewUint32DelimitedWriter(w, binary.BigEndian)
 		defer enc.Close()
-		defer watcher.Close()
+		defer watcher.ConsumerGone()
 
 		var buf logdriver.LogEntry
 		for {

--- a/driver.go
+++ b/driver.go
@@ -103,7 +103,7 @@ func consumeLog(lf *logPair) {
 		var msg logger.Message
 		msg.Line = buf.Line
 		msg.Source = buf.Source
-		msg.Partial = buf.Partial
+		//		msg.Partial = buf.Partial
 		msg.Timestamp = time.Unix(0, buf.TimeNano)
 
 		if err := lf.l.Log(&msg); err != nil {
@@ -146,7 +146,7 @@ func (d *driver) ReadLogs(info logger.Info, config logger.ReadConfig) (io.ReadCl
 				}
 
 				buf.Line = msg.Line
-				buf.Partial = msg.Partial
+				//				buf.Partial = msg.Partial
 				buf.TimeNano = msg.Timestamp.UnixNano()
 				buf.Source = msg.Source
 


### PR DESCRIPTION
Change in the LogWatcher Module change required watcher.Close() to be changed to watcher.ConsumerGone().